### PR TITLE
Revert LevelDB.txt

### DIFF
--- a/Leveldb.net/DB.cs
+++ b/Leveldb.net/DB.cs
@@ -25,7 +25,6 @@ namespace LevelDB
         private Logger _InfoLog;
         private Comparator _Comparator;
         private Encoding _encoding;
-        private static string _CallLog;
         private static ReadOptions _DefaultReadOptions = new ReadOptions();
         private static WriteOptions _DefaultWriteOptions = new WriteOptions();
 
@@ -68,9 +67,6 @@ namespace LevelDB
             this._encoding = encoding;
             this._Logger.IsDebugEnabled = options.IsInternalDebugLoggerEnabled;
 
-            if (this._Logger.IsDebugEnabled)
-                _CallLog = this._Logger.CallLog;
-
             Throw(error, msg => new UnauthorizedAccessException(msg));
         }
 
@@ -82,15 +78,7 @@ namespace LevelDB
             {
                 try
                 {
-                    if (logger.LogCall(funcName, args))
-                    {
-                        error = func();
-                        File.Delete(_CallLog);
-                    }
-                    else
-                    {
-                        error = func();
-                    }
+                    error = func();
                 }
                 catch (Exception x)
                 {

--- a/Leveldb.net/DB.cs
+++ b/Leveldb.net/DB.cs
@@ -83,6 +83,8 @@ namespace LevelDB
                 catch (Exception x)
                 {
                     logger.Error(x.ToString(), args);
+
+                    throw x;
                 }
             }
 

--- a/Leveldb.net/InternalLogger.cs
+++ b/Leveldb.net/InternalLogger.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 
 namespace LevelDB
@@ -69,22 +66,8 @@ namespace LevelDB
             get; set;
         }
 
-        private const int MaxCallLogs = 3;
-
-        private List<string> callLogs;
-        public readonly string CallLog;
-
         private InternalLogger()
         {
-            var nodeLog = _Logger.Factory.Configuration.ConfiguredNamedTargets
-                .Where(t => t is NLog.Targets.FileTarget fileTarget)
-                .Select(t => ((NLog.Targets.FileTarget)t).FileName.ToString())
-                .FirstOrDefault();
-
-            if (nodeLog != null)
-                CallLog = Path.Combine(Path.GetDirectoryName(nodeLog.Replace("'", "")), "LevelDB.txt");
-
-            this.callLogs = new List<string>();
         }
 
         public static InternalLogger Create()
@@ -102,24 +85,6 @@ namespace LevelDB
             return args.Select(a => '[' + a.ToString() + ']').Aggregate((a, b) => a + ", " + b);
         }
 
-
-        public bool LogCall(string message, params Stringable[] args)
-        {
-            if (!this.IsDebugEnabled || CallLog == null)
-                return false;
-
-            string dateStr = DateTime.Now.ToString("[yyyy-MM-dd HH:mm:ss.fff]");
-
-            StackTrace stackTrace = new StackTrace();
-
-            callLogs.Add($"{dateStr} {message}: {ToString(args)}: { stackTrace }");
-            if (callLogs.Count > MaxCallLogs)
-                callLogs.RemoveAt(0);
-
-            File.WriteAllLines(CallLog, callLogs);
-
-            return true;
-        }
 
         public void Debug(string message, params Stringable[] args)
         {


### PR DESCRIPTION
This PR reverts a change that was made to troubleshoot cases where the node aborts before managing to log anything.

Since that scenario has now been addressed this change is no longer required.